### PR TITLE
script flask fixed

### DIFF
--- a/server_backend/DEVELOPMENT_running_script/run_sql_refresh_and_flask.sh
+++ b/server_backend/DEVELOPMENT_running_script/run_sql_refresh_and_flask.sh
@@ -2,8 +2,8 @@
 
 # Assuming you're already in the 'server_backend' directory and in venv
 
-# Load environment variables from the .env file
-export $(grep -v '^#' ../.env | xargs)
+# Load specific environment variables from the .env file
+export $(grep -E '^RESULTS_BASE_DIR_PATH=|^VUE_APP_BACKEND_PORT=' ../.env | xargs)
 
 # Run the SQL files in the specified order
 echo "Running drop_tables.sql..."
@@ -226,13 +226,13 @@ for i in {4..4}; do
     fi
 done
 
-
 # Get the Flask port from the environment variable
 FLASK_PORT=$VUE_APP_BACKEND_PORT
 
 # Stop any process running on the specified port
 # Remove any carriage return (\r) that might exist if editing on Windows
 FLASK_PORT=$(echo $FLASK_PORT | tr -d '\r')
+MYSQL_HOST=$(echo $MYSQL_HOST | tr -d '\r')
 
 # Find the PID of the process using the port and kill it
 FLASK_PID=$(lsof -t -i :$FLASK_PORT)


### PR DESCRIPTION
- Can now run script and use that flask without endpoints causing errors
- Errors were caused from env variable overlap with my.cnf file AND carriage return (\r) since script was written from Windows machine but ran on Linux