### PR TITLE
ParticipantID added to parameters sent to tracking script

### DIFF
--- a/frontend/src/views/SessionForm.vue
+++ b/frontend/src/views/SessionForm.vue
@@ -43,16 +43,21 @@ export default {
     },
 
     async getSessionID() {
-      try{
+      try {
         const backendUrl = this.$backendUrl
         const path = `${backendUrl}/create_participant_session/${this.studyId}`
         const response = await axios.get(path)
         this.participantSessId = response.data.participant_session_id
-        console.log("Session ID: ", this.participantSessId)
-      } catch(error) {
+        console.log('Session ID: ', this.participantSessId)
+        if (this.participantSessId) {
+          // only allow the session to start and info the be passed to local flask if participant id is available
+          this.study.participantSessId = this.participantSessId
+          this.startSession()
+        }
+      } catch (error) {
         console.error('Error:', error.response?.data || error.message)
       }
-    }
+    },
 
     async startSession() {
       try {


### PR DESCRIPTION
Should now have everything on the local flask to run the script. New pieces added that were not there before Jairo are the task id's, factor id's, task directions, and participant_session_id. To send a csv to the db, for each csv we need the unique combination of taskid, factorid, participant_session_id, and measurement_type 