### PR TITLE
135 Big Update to Local Scripts + Sending Results to Server 

### DIFF
--- a/frontend/public/sample_study.json
+++ b/frontend/public/sample_study.json
@@ -37,7 +37,7 @@
       "taskName": "Task A"
     },
     "22": {
-      "measurementOptions": ["Keyboard Inputs"],
+      "measurementOptions": ["Mouse Movement", "Heat Map", "Screen Recording"],
       "taskDescription": "Task Des",
       "taskDirections": "Start spamming keyboard lil bru",
       "taskDuration": null,
@@ -53,6 +53,5 @@
       "factorDescription": "Factor Der",
       "factorName": "Table"
     }
-  },
-  "storagePath": "C:/Users/brand/Fulcrum_Results"
+  }
 }

--- a/frontend/src/components/Task.vue
+++ b/frontend/src/components/Task.vue
@@ -31,12 +31,7 @@
     <div>
       <v-select
         v-model="task.measurementOptions"
-        :items="[
-          'Mouse Movement',
-          'Mouse Scrolls',
-          'Mouse Clicks',
-          'Keyboard Inputs',
-        ]"
+        :items="updateVisibleMeasurementOptions"
         label="Measurement Options"
         chips
         multiple
@@ -103,6 +98,46 @@ export default {
         rule => rule(this.task.taskDuration) === true,
       )
       return taskNameCheck && taskDescCheck && taskDirCheck && taskDurCheck
+    },
+  },
+
+  // Used to remove Heat Map selection if Mouse Movement is deselected since it is dependent on it
+  watch: {
+    'task.measurementOptions'(newSelection) {
+      if (!newSelection.includes('Mouse Movement')) {
+        this.$emit('update:task', {
+          ...this.task,
+          measurementOptions: newSelection.filter(
+            option => option !== 'Heat Map',
+          ),
+        })
+      }
+    },
+  },
+
+  // Changes selection options to include Heat Map when Mouse Movement is actively selected and vice versa
+  computed: {
+    updateVisibleMeasurementOptions() {
+      if (this.task.measurementOptions.includes('Mouse Movement')) {
+        return [
+          // Heat Map should be visible since MM is selected
+          'Mouse Movement',
+          'Mouse Scrolls',
+          'Mouse Clicks',
+          'Keyboard Inputs',
+          'Screen Recording',
+          'Heat Map',
+        ]
+      } else {
+        return [
+          // Heat Map unavailable when Mouse Movement not selected
+          'Mouse Movement',
+          'Mouse Scrolls',
+          'Mouse Clicks',
+          'Keyboard Inputs',
+          'Screen Recording',
+        ]
+      }
     },
   },
 }

--- a/frontend/src/views/StudyForm.vue
+++ b/frontend/src/views/StudyForm.vue
@@ -53,7 +53,11 @@
                   </template>
                 </v-expansion-panel-title>
                 <v-expansion-panel-text>
-                  <Task :ref="el => (taskRefs[index] = el)" :task="task" />
+                  <Task
+                    :ref="el => (taskRefs[index] = el)"
+                    :task="tasks[index]"
+                    @update:task="updateTask(index, $event)"
+                  />
                 </v-expansion-panel-text>
               </v-expansion-panel>
             </v-expansion-panels>
@@ -349,6 +353,10 @@ export default {
         this.factors.pop()
         this.expandedFPanels = this.expandedFPanels.filter(i => i !== fIndex)
       }
+    },
+
+    updateTask(index, updatedTask) {
+      this.tasks[index] = { ...updatedTask }
     },
 
     // prevent task expansion panels from collapsing while input is invalid

--- a/local_backend/driver.py
+++ b/local_backend/driver.py
@@ -6,6 +6,7 @@ import json
 import threading
 import os
 import time
+from datetime import datetime
 
 # PyQt libraries
 from PyQt6.QtCore import Qt, QSize, QTimer
@@ -34,12 +35,14 @@ from tracking.utility.screenrecording import (
     adjustments_finished,
 )
 from tracking.utility.heatmap import heatmap_generation_complete
-
+from routes.send_server import send_to_server
 
 # Ref https://www.pythonguis.com/tutorials/pyqt6-widgets/
 class GlobalToolbar(QWidget):
     def __init__(self):
         super().__init__()
+        self.session_json = {}
+        self.sessions_start_time = None
         self.setup_ui()
         self.show()
         self.initiate_setup()
@@ -171,6 +174,7 @@ class GlobalToolbar(QWidget):
         # Uses a sample json found in frontend/public for easier debugging and development so we dont have to initiate session from Vue
         with open("../frontend/public/sample_study.json", "r") as file:
             data = json.load(file)
+            self.session_json = data
         self.session_id, self.tasks, self.factors, self.trials = (
             self.parse_study_details(data)
         )
@@ -268,54 +272,90 @@ class GlobalToolbar(QWidget):
     
     
     # Need to get a dir path to know where to save the results locally (for redundancy)
-    def get_storage_loc(self):
-        storage_dir = None
-        
-        while not storage_dir:
-            storage_dir = QFileDialog.getExistingDirectory(self, "Storage Location")
+    def get_storage_loc(self):        
+        while True:
+            storage_dir = QFileDialog.getExistingDirectory(self, "Select Storage Location")
+            
             if not storage_dir:
-                QMessageBox.warning(self, "Folder Selection Required", "Please try again! Storage Location Required to Continue.")
+                QMessageBox.warning(self, "Selection Required", "Storage location is mandatory. Please try again!")
+            
+            elif not self.validate_storage_loc(storage_dir):
+                QMessageBox.warning(self, "Invalid Folder Selected", "No permission to write to this location. Try a new folder!")
                 
-        return storage_dir
+            else:
+                return storage_dir
+    
+    
+    # Some locations like OneDrive are currently problematic so avoid accepting those until I can figure out a way to validate paths better
+    def validate_storage_loc(self, output_path):
+        if not output_path or not os.path.exists(output_path):
+            return False
         
+        unsupported_locations = ["OneDrive", "Google Drive", "Dropbox"]
+        if (any(keyword.lower() in output_path.lower() for keyword in unsupported_locations)):
+            return False
+        
+        return True
+        
+        # temp_dir = os.path.join(output_path, "temp_folder")
+        # temp_file = os.path.join(temp_dir, "temp_file.txt")
+        
+        # try:
+        #     os.makedirs(temp_dir, exist_ok=True)
+        #     with open(temp_file, "w") as f:
+        #         f.write("X" * 1024)
+        #     os.remove(temp_file)
+        #     os.rmdir(temp_dir)
+        #     return True
+        
+        # except PermissionError:
+        #     return False
+        
+        # except Exception as e:
+        #     print(f"Error trying to validate storage directory: {e}")
+        #     return False
+    
 
     def start_session(self):
         self.move_next_task()  # start btn treated same way as moving to next task essentially
 
 
     def move_next_task(self):
-        # Get next trial's details
-        trial = self.trials[self.trial_index]
-        task_id = str(trial["taskID"])
-        task = self.tasks[task_id]
-        task_dirs = task["taskDirections"]
-        task_dur = task.get("taskDuration", None)
-        factor_id = str(trial["factorID"])
-        factor = self.factors[factor_id]
-
-        # Confirm the use wants to move on
-        trial_msg = QMessageBox()
-        trial_msg.setWindowTitle(f"Task {self.trial_index + 1}")
-        if task_dur:
-            trial_msg.setText(f"Directions: {task_dirs}\nDuration: {task_dur} minutes")
+        # Confirm user wants to move on
+        trial_end_msg = QMessageBox()
+        if self.trial_index > 0:
+            trial_end_msg.setWindowTitle(f"End Task {self.trial_index}?")
         else:
-            trial_msg.setText(f"Directions: {task_dirs}\nDuration: No time limit")
-
-        trial_msg.setStandardButtons(
+            trial_end_msg.setWindowTitle(f"Begin")
+        trial_end_msg.setText(f"Are you ready to start Task {self.trial_index + 1}?")
+        trial_end_msg.setStandardButtons(
             QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
         )
 
-        if trial_msg.exec() == QMessageBox.StandardButton.Ok:
+        if trial_end_msg.exec() == QMessageBox.StandardButton.Ok:
+            if self.trial_index == 0:
+                # Timestamp useful for saving to filesytem
+                start_time = time.time()
+                self.sessions_start_time = datetime.fromtimestamp(start_time).strftime("%Y-%m-%d %H:%M:%S")
+                print(f"Start time: {self.sessions_start_time}")
             if self.trial_index > 0:
+                # Make sure prior trial's details are saved before moving fwd 
                 stop_event.set()
                 pause_event.clear()
-                data_storage_complete_event.wait()
-                heatmap_generation_complete.wait()
-
-                # Recording signals
                 recording_stop.set()
-                while recording_active.is_set():
-                    time.sleep(0.1)
+                self.wait_trial_save()
+                
+            # Get next trial's details
+            trial = self.trials[self.trial_index]
+            task_id = str(trial["taskID"])
+            task = self.tasks[task_id]
+            task_dirs = task["taskDirections"]
+            task_dur = task.get("taskDuration", None)
+            factor_id = str(trial["factorID"])
+            factor = self.factors[factor_id]
+        
+            # Display info for new trial
+            self.display_new_trial_info(task_dur, task_dirs)
 
             self.start_btn.setEnabled(False)  # disable for the rest of the session
             self.session_paused = False
@@ -331,7 +371,7 @@ class GlobalToolbar(QWidget):
 
             trial_thread = threading.Thread(
                 target=conduct_trial,
-                args=(self.session_id, task, factor, self.storage_dir),
+                args=(self.session_id, task, factor, self.storage_dir, (self.trial_index + 1)),
             )
             trial_thread.start()
 
@@ -353,6 +393,30 @@ class GlobalToolbar(QWidget):
             self.progress.setText(f"Task {self.trial_index} of {len(self.trials)}")
 
 
+
+    # Show details of current trial in pop-up
+    def display_new_trial_info(self, dur, dir):
+        trial_start_msg = QMessageBox()
+        trial_start_msg.setWindowTitle(f"Task {self.trial_index + 1}")
+        if dur:
+            trial_start_msg.setText(f"Directions: {dir}\nDuration: {dur} minutes")
+        else:
+            trial_start_msg.setText(f"Directions: {dir}\nDuration: No time limit")
+
+        trial_start_msg.setStandardButtons(
+            QMessageBox.StandardButton.Ok
+        )
+        # Customize to prevent close button from actually working
+        trial_start_msg.setWindowFlags(
+            Qt.WindowType.Dialog |
+            Qt.WindowType.WindowStaysOnTopHint |
+            Qt.WindowType.CustomizeWindowHint |
+            Qt.WindowType.WindowTitleHint
+        )
+        
+        trial_start_msg.exec()
+        
+        
     # Starts the countdown timer
     def initiate_countdown(self, duration):
         self.next_btn.setEnabled(False)
@@ -492,55 +556,84 @@ class GlobalToolbar(QWidget):
                 self.trial_index > 0
             ):  # only attempt to save results if they completed at least 1 trial
 
-                # Add pop-up in case local saving results (mp4, heatmap, csv's) takes a while before the app can close so user doesn't mistake for frozen
-                save_msg = QDialog(self)
-                save_msg.setWindowTitle("Session Complete!")
-                save_msg.setWindowFlags(
-                    Qt.WindowType.Dialog
-                    | Qt.WindowType.WindowStaysOnTopHint
-                    | Qt.WindowType.CustomizeWindowHint
-                    | Qt.WindowType.WindowTitleHint
-                )
-
-                save_msg.setFixedSize(400, 100)
-
-                x_pos, y_pos = self.get_dialog_placement_pos(save_msg)
-                save_msg.move(x_pos, y_pos)
-
-                layout = QVBoxLayout(save_msg)
-                save_label = QLabel("Saving results... This may take a while.")
-                save_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                save_label.setStyleSheet("color: white; font-size: 12pt;")
-                layout.addWidget(save_label)
-
-                save_msg.show()
-                QApplication.processEvents()
-
                 pause_event.clear()
                 stop_event.set()
 
-                # Have to use while loops here or else while waiting the overlaying pop-up will freeze. Using this we can invoke an update to UI
-                while (
-                    not data_storage_complete_event.is_set()
-                    or not heatmap_generation_complete.is_set()
-                ):
-                    time.sleep(0.1)
-                    QApplication.processEvents()
-
-                recording_stop.set()
-                while recording_active.is_set():
-                    time.sleep(0.1)
-                    QApplication.processEvents()
-
-                adjustments_finished.wait()
-
-                if os.path.exists(get_save_dir(self.storage_dir, self.session_id)):
+                self.wait_trial_save()
+                
+                session_path = get_save_dir(self.storage_dir, self.session_id)
+                
+                if os.path.exists(session_path):
                     try:
                         package_session_results(self.session_id, self.storage_dir)
                     except Exception as e:
                         print(f"Error packaging data: {e}")
+                    
+                zip_path = os.path.join(self.storage_dir, f"session_results_{self.session_id}.zip")
+                
+                if os.path.exists(zip_path):
+                    try:
+                        self.session_json["session_start_time"] = self.sessions_start_time
+                        send_to_server(zip_path, self.session_json)
+                    except Exception as e:
+                        print(f"Error sending json: {e}")
 
             QApplication.quit()
+            
+    # Used to make sure the current trial's data saved before advancing to avoid race conditions and data loss of fatter prior trials
+    def wait_trial_save(self):
+        # Add pop-up in case local saving results (mp4, heatmap, csv's) takes a while before the app can close so user doesn't mistake for frozen
+        save_msg = QDialog(self)
+        save_msg.setWindowTitle("Task Complete!")
+        save_msg.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.CustomizeWindowHint
+            | Qt.WindowType.WindowTitleHint
+        )
+
+        save_msg.setFixedSize(400, 100)
+
+        x_pos, y_pos = self.get_dialog_placement_pos(save_msg)
+        save_msg.move(x_pos, y_pos)
+
+        layout = QVBoxLayout(save_msg)
+        save_label = QLabel("Saving results... This may take a while.")
+        save_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        save_label.setStyleSheet("color: white; font-size: 12pt;")
+        layout.addWidget(save_label)
+
+        save_msg.show()
+        QApplication.processEvents()
+        
+        # Have to use while loops here or else while waiting the overlaying pop-up will freeze. Using this we can invoke an update to UI
+        if not data_storage_complete_event.is_set():
+            while (not data_storage_complete_event.is_set()):
+                time.sleep(0.1)
+                QApplication.processEvents()
+        
+        curr_trial = self.trials[self.trial_index - 1]
+        curr_task_id = str(curr_trial["taskID"])
+        curr_task = self.tasks[curr_task_id]
+        curr_measurements = curr_task["measurementOptions"]
+        
+        if "Heat Map" in curr_measurements and not heatmap_generation_complete.is_set():
+            while (not heatmap_generation_complete.is_set()):
+                time.sleep(0.1)
+                QApplication.processEvents()
+                
+        if recording_active.is_set():
+            recording_stop.set()
+            while recording_active.is_set():
+                time.sleep(0.1)
+                QApplication.processEvents()
+
+        if "Screen Recording" in curr_measurements and not adjustments_finished.is_set():
+            while not adjustments_finished.is_set():
+                time.sleep(0.1)
+                QApplication.processEvents()
+                
+        save_msg.close()
 
 
     # Ref https://stackoverflow.com/questions/41784521/move-qtwidgets-qtwidget-using-mouse for how to make toolbar draggable

--- a/local_backend/routes/send_server.py
+++ b/local_backend/routes/send_server.py
@@ -1,21 +1,22 @@
 import requests
 import json
 
+
 def send_to_server(zip_local_path, session_json):
     # Make more robust eventually. Also, you will have to change it from 5003 to your port
     server_url = "http://100.82.85.28:5003/test_local_to_server"
 
     try:
-        with open(zip_local_path, 'rb') as file:
-            files = {'file': file}
-            data = {'json': json.dumps(session_json)}
-            
+        with open(zip_local_path, "rb") as file:
+            files = {"file": file}
+            data = {"json": json.dumps(session_json)}
+
             response = requests.post(server_url, files=files, data=data)
 
             if response.status_code == 200:
                 print("Successfully sent results to server")
             else:
                 print("Unexpected response:", response.status_code, response.text)
-        
+
     except requests.exceptions.RequestException as e:
         print("Saving failed", e)

--- a/local_backend/routes/send_server.py
+++ b/local_backend/routes/send_server.py
@@ -1,0 +1,21 @@
+import requests
+import json
+
+def send_to_server(zip_local_path, session_json):
+    # Make more robust eventually. Also, you will have to change it from 5003 to your port
+    server_url = "http://100.82.85.28:5003/test_local_to_server"
+
+    try:
+        with open(zip_local_path, 'rb') as file:
+            files = {'file': file}
+            data = {'json': json.dumps(session_json)}
+            
+            response = requests.post(server_url, files=files, data=data)
+
+            if response.status_code == 200:
+                print("Successfully sent results to server")
+            else:
+                print("Unexpected response:", response.status_code, response.text)
+        
+    except requests.exceptions.RequestException as e:
+        print("Saving failed", e)

--- a/local_backend/tracking/tracking.py
+++ b/local_backend/tracking/tracking.py
@@ -32,9 +32,7 @@ def conduct_trial(sess_id, task, factor, storage_path, trial_num):
 
     # Only screen record current trial if requested (no longer all trials)
     if measurement_flags["screen_recording"]:
-        recorder_thread = threading.Thread(
-            target=record_screen, args=(dir_trial,)
-        )
+        recorder_thread = threading.Thread(target=record_screen, args=(dir_trial,))
         recorder_thread.start()
 
     # Start tracking as long as at least 1 option was selected for the current task
@@ -46,9 +44,7 @@ def conduct_trial(sess_id, task, factor, storage_path, trial_num):
     if measurement_flags["heat_map"]:
         data_storage_complete_event.wait()
         heatmap_generation_complete.clear()
-        heatmap_thread = threading.Thread(
-            target=generate_heatmap, args=(dir_trial,)
-        )
+        heatmap_thread = threading.Thread(target=generate_heatmap, args=(dir_trial,))
         heatmap_thread.start()
     else:
         heatmap_generation_complete.set()

--- a/local_backend/tracking/tracking.py
+++ b/local_backend/tracking/tracking.py
@@ -10,7 +10,7 @@ from .utility.file_management import get_save_dir
 
 
 # Running a single trial (task-factor combo) at this point
-def conduct_trial(sess_id, task, factor, storage_path):
+def conduct_trial(sess_id, task, factor, storage_path, trial_num):
     # Debugging purposes
     print(f"Starting trial for task {task['taskName']}, factor {factor['factorName']}")
 
@@ -27,32 +27,27 @@ def conduct_trial(sess_id, task, factor, storage_path):
     }
 
     # Find the base trial dir path to save to
-    dir_trial = get_save_dir(storage_path, sess_id, task, factor)
+    dir_trial = get_save_dir(storage_path, sess_id, task, factor, trial_num)
     os.makedirs(dir_trial, exist_ok=True)
-
-    # Finding the base filename convention (excludes the file format and measurement type)
-    task_name = task["taskName"].replace(" ", "")
-    factor_name = factor["factorName"].replace(" ", "")
-    filename_base = f"{sess_id}_{task_name}_{factor_name}"
 
     # Only screen record current trial if requested (no longer all trials)
     if measurement_flags["screen_recording"]:
         recorder_thread = threading.Thread(
-            target=record_screen, args=(dir_trial, filename_base)
+            target=record_screen, args=(dir_trial,)
         )
         recorder_thread.start()
 
     # Start tracking as long as at least 1 option was selected for the current task
     if any(measurement_flags.values()):
         data_storage_complete_event.clear()  # reset at the start of a trial
-        record_measurements(task, measurement_flags, dir_trial, filename_base)
+        record_measurements(task, measurement_flags, dir_trial)
 
     # will want to change this eventually so only heatmap generated if the researcher requested it instead of always when mouse movement is involved
     if measurement_flags["heat_map"]:
         data_storage_complete_event.wait()
         heatmap_generation_complete.clear()
         heatmap_thread = threading.Thread(
-            target=generate_heatmap, args=(dir_trial, filename_base)
+            target=generate_heatmap, args=(dir_trial,)
         )
         heatmap_thread.start()
     else:

--- a/local_backend/tracking/utility/file_management.py
+++ b/local_backend/tracking/utility/file_management.py
@@ -8,7 +8,7 @@ import shutil  # used to remove folder once zip is created
 
 
 # Returns the path to a directory for a session or trial depending on what parameters are passed
-def get_save_dir(storage_path, sess_id, task=None, factor=None):
+def get_save_dir(storage_path, sess_id, task=None, factor=None, trial_num = None):
     # path to session folder
     dir_session = os.path.join(storage_path, f"Session_{sess_id}")
 
@@ -16,17 +16,17 @@ def get_save_dir(storage_path, sess_id, task=None, factor=None):
         return dir_session
 
     # path to trial folder
-    task_name = task["taskName"].replace(" ", "")
-    factor_name = factor["factorName"].replace(" ", "")
+    task_name = task["taskName"]
+    factor_name = factor["factorName"]
 
-    dir_trial = os.path.join(dir_session, f"{task_name}_{factor_name}")
+    dir_trial = os.path.join(dir_session, f"{task_name}_{factor_name}_trial_{trial_num}")
 
     return dir_trial
 
 
 # Constructs the full file path and enforces a naming convention
-def get_file_path(dir_trial, filename_trial_base, measurement_type, file_format):
-    file_name = f"{filename_trial_base}_{measurement_type}.{file_format}"
+def get_file_path(dir_trial, measurement_type, file_format):
+    file_name = f"{measurement_type}.{file_format}"
     full_path = os.path.join(dir_trial, file_name)
 
     return full_path
@@ -34,12 +34,12 @@ def get_file_path(dir_trial, filename_trial_base, measurement_type, file_format)
 
 # Generating a unique csv based on the measurement type during a given trial
 def write_to_csv(
-    measurement_type, feature, arr_data, is_used, task, dir_trial, filename_base
+    measurement_type, feature, arr_data, is_used, task, dir_trial
 ):
     if not is_used:
         return
 
-    file_path = get_file_path(dir_trial, filename_base, measurement_type, "csv")
+    file_path = get_file_path(dir_trial, measurement_type, "csv")
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
     # Prevent writing values that exceeded task duration due to delay between signaling task end and stopping tracking threads
@@ -88,16 +88,3 @@ def package_session_results(session_id, storage_path):
         print(f"Session {session_id} results saved to {zip_path}!")
     except Exception as e:
         print(f"Error occured while trying to package session {session_id}: {e}")
-
-
-###################################################
-
-# @app.route("/retrieve_zip/<zip_name>", methods=["GET"])
-# def retrieve_zip(zip_name):
-#     z_path = os.path.join(os.getcwd(), zip_name)
-#     if os.path.exists(z_path) and zip_name.endswith('.zip'):
-#         return send_file(z_path, as_attachment=True)
-#     else:
-#         return "", 200
-
-###################################################

--- a/local_backend/tracking/utility/file_management.py
+++ b/local_backend/tracking/utility/file_management.py
@@ -8,7 +8,7 @@ import shutil  # used to remove folder once zip is created
 
 
 # Returns the path to a directory for a session or trial depending on what parameters are passed
-def get_save_dir(storage_path, sess_id, task=None, factor=None, trial_num = None):
+def get_save_dir(storage_path, sess_id, task=None, factor=None, trial_num=None):
     # path to session folder
     dir_session = os.path.join(storage_path, f"Session_{sess_id}")
 
@@ -19,7 +19,9 @@ def get_save_dir(storage_path, sess_id, task=None, factor=None, trial_num = None
     task_name = task["taskName"]
     factor_name = factor["factorName"]
 
-    dir_trial = os.path.join(dir_session, f"{task_name}_{factor_name}_trial_{trial_num}")
+    dir_trial = os.path.join(
+        dir_session, f"{task_name}_{factor_name}_trial_{trial_num}"
+    )
 
     return dir_trial
 
@@ -33,9 +35,7 @@ def get_file_path(dir_trial, measurement_type, file_format):
 
 
 # Generating a unique csv based on the measurement type during a given trial
-def write_to_csv(
-    measurement_type, feature, arr_data, is_used, task, dir_trial
-):
+def write_to_csv(measurement_type, feature, arr_data, is_used, task, dir_trial):
     if not is_used:
         return
 

--- a/local_backend/tracking/utility/heatmap.py
+++ b/local_backend/tracking/utility/heatmap.py
@@ -15,15 +15,15 @@ from tracking.utility.file_management import get_file_path
 heatmap_generation_complete = threading.Event()
 
 
-def generate_heatmap(dir_trial, filename_base):
+def generate_heatmap(dir_trial):
     # Capture screenshot
-    screenshot_path = get_file_path(dir_trial, filename_base, "screenshot", "png")
+    screenshot_path = get_file_path(dir_trial, "screenshot", "png")
     screenshot = ImageGrab.grab()
     screenshot.save(screenshot_path)
     screenshot = cv2.imread(screenshot_path)
 
     # Retrieve path to the mouse movement csv needed to create the heatmap
-    mouse_data_path = get_file_path(dir_trial, filename_base, "MouseMovement", "csv")
+    mouse_data_path = get_file_path(dir_trial, "Mouse Movement", "csv")
 
     # Extract mouse movement coordinates
     coordinates = extract_mouse_movements(mouse_data_path)
@@ -36,7 +36,7 @@ def generate_heatmap(dir_trial, filename_base):
         overlay = overlay_heatmap(heatmap, screenshot)
 
         # Save the output
-        heatmap_path = get_file_path(dir_trial, filename_base, "heatmap", "png")
+        heatmap_path = get_file_path(dir_trial, "Heat Map", "png")
         cv2.imwrite(heatmap_path, overlay)
 
         time.sleep(1)

--- a/local_backend/tracking/utility/measure.py
+++ b/local_backend/tracking/utility/measure.py
@@ -39,7 +39,7 @@ curr_time = 0
 prev_time = 0
 
 
-def on_move(x, y, task, dir_trial, filename_base):
+def on_move(x, y, task, dir_trial):
     global PREV_XPOS, PREV_YPOS, curr_time, prev_time, running_time, mouse_move_data
 
     if not pause_event.is_set():  # ignore logging when paused
@@ -66,7 +66,6 @@ def on_move(x, y, task, dir_trial, filename_base):
                 "mouse",
                 task,
                 dir_trial,
-                filename_base,
             )
             mouse_move_data.clear()
 
@@ -162,7 +161,7 @@ def stop_keyboard_ps():
 
 
 # Manages the actual data collection, using measurement flags to know what to collect for the current trial
-def record_measurements(task, tracking_flags, dir_trial, filename_base):
+def record_measurements(task, tracking_flags, dir_trial):
     global mouse_listener, key_listener, running_time, keyboard_data, running_time, paused_time, mouse_move_data, mouse_click_data, mouse_scroll_data
 
     running_time = time.time()
@@ -175,7 +174,7 @@ def record_measurements(task, tracking_flags, dir_trial, filename_base):
             stop_keyboard_ps()
 
         def on_move_params(x, y):
-            on_move(x, y, task, dir_trial, filename_base)
+            on_move(x, y, task, dir_trial)
 
         # Initialize mouse listener if needed
         if (
@@ -216,40 +215,36 @@ def record_measurements(task, tracking_flags, dir_trial, filename_base):
 
         # Writing before the current task ends
         write_to_csv(
-            "MouseMovement",
+            "Mouse Movement",
             "mouse",
             mouse_move_data,
             tracking_flags["mouse_movement"],
             task,
             dir_trial,
-            filename_base,
         )
         write_to_csv(
-            "KeyboardInputs",
+            "Keyboard Inputs",
             "keyboard",
             keyboard_data,
             tracking_flags["keyboard_inputs"],
             task,
             dir_trial,
-            filename_base,
         )
         write_to_csv(
-            "MouseClicks",
+            "Mouse Clicks",
             "mouse",
             mouse_click_data,
             tracking_flags["mouse_clicks"],
             task,
             dir_trial,
-            filename_base,
         )
         write_to_csv(
-            "MouseScrolls",
+            "Mouse Scrolls",
             "mouse",
             mouse_scroll_data,
             tracking_flags["mouse_scrolls"],
             task,
             dir_trial,
-            filename_base,
         )
 
         # Resetting for next trial

--- a/local_backend/tracking/utility/screenrecording.py
+++ b/local_backend/tracking/utility/screenrecording.py
@@ -74,9 +74,9 @@ def record_screen(dir_output_base, filename_base):
 
         recording_active.clear()
 
-        # adjuster_thread = threading.Thread(target = adjust_video, args = (file_path, fps))
-        # adjuster_thread.daemon = True
-        # adjuster_thread.start()
+        adjuster_thread = threading.Thread(target = adjust_video, args = (file_path, fps))
+        adjuster_thread.daemon = True
+        adjuster_thread.start()
 
 
 # Need this function because fps varies for each person so we have to correct the video using calculated fps using ffmpeg or else play speed and video length will be incorrect

--- a/local_backend/tracking/utility/screenrecording.py
+++ b/local_backend/tracking/utility/screenrecording.py
@@ -74,7 +74,7 @@ def record_screen(dir_output_base):
 
         recording_active.clear()
 
-        adjuster_thread = threading.Thread(target = adjust_video, args = (file_path, fps))
+        adjuster_thread = threading.Thread(target=adjust_video, args=(file_path, fps))
         adjuster_thread.daemon = True
         adjuster_thread.start()
 

--- a/local_backend/tracking/utility/screenrecording.py
+++ b/local_backend/tracking/utility/screenrecording.py
@@ -20,7 +20,7 @@ recording_active = threading.Event()
 adjustments_finished = threading.Event()
 
 
-def record_screen(dir_output_base, filename_base):
+def record_screen(dir_output_base):
     # Reset
     recording_stop.clear()
     adjustments_finished.clear()
@@ -28,7 +28,7 @@ def record_screen(dir_output_base, filename_base):
     # Signal we are recording
     recording_active.set()
 
-    file_path = get_file_path(dir_output_base, filename_base, "screen_recording", "mp4")
+    file_path = get_file_path(dir_output_base, "Screen Recording", "mp4")
 
     temp_fps = 15
     delay = 1 / temp_fps


### PR DESCRIPTION
- scripts now use heat maps and screen recordings in the session flow as options rather than always generating them for all trials
- added watch & compute fxns to Task.Vue so that Heat Map generation can NOT be selected unless Mouse Movement is also selected since it uses it
- changed naming conventions of generated zip file to align with filesystem structure for simplicity (love you Nic my pookie)
- created a endpoint to send the zip file from the local script straight to the file system which sends both the zip and session json to make placement easier (send_server.py)
- added a a facilitator setup screen to let the facilitator select their desired local output directory for results
- added functionality to validate the path will not have permission issues such as with OneDrive
- made move_next_task() more modular, moving some of the pop-up window code into separate functions
- added some more pop-ups for between trials to make the flow more intuitive 
- MASSIVE improvement to threading synchronization so that the writes/saves are completely done and threads are cleaned up between individual trials which also helps with performance by limiting the number of threads active at once and also helps prevent race conditions between trials 