### PR TITLE
142 post endpoint for saving session zips to filesystem and database

### DIFF
--- a/frontend/public/sample_study.json
+++ b/frontend/public/sample_study.json
@@ -9,7 +9,7 @@
     {
       "taskID": 1,
       "factorID": 1,
-      "createdAt": "2025-03-07 14:56:42"
+      "createdAt": "2025-03-07 14:56:41"
     },
     {
       "taskID": 1,
@@ -19,12 +19,12 @@
     {
       "taskID": 1,
       "factorID": 1,
-      "createdAt": "2025-03-07 14:56:42"
+      "createdAt": "2025-03-07 14:56:43"
     },
     {
       "taskID": 1,
       "factorID": 1,
-      "createdAt": "2025-03-07 14:56:42"
+      "createdAt": "2025-03-07 14:56:44"
     }
   ],
   "tasks": {

--- a/frontend/public/sample_study.json
+++ b/frontend/public/sample_study.json
@@ -1,57 +1,50 @@
 {
-  "participantSessId": 9,
-  "study_id": "11",
-  "studyName": "Study Name",
-  "studyDescription": "Study Desc",
-  "studyDesignType": "Between",
-  "participantCount": "214",
+  "participantSessId": 4,
+  "study_id": "1",
+  "studyName": "Memory and Attention",
+  "studyDescription": "Study on memory retention and focus.",
+  "studyDesignType": "Within",
+  "participantCount": "50",
   "trials": [
     {
-      "taskID": 21,
-      "factorID": 41
+      "taskID": 1,
+      "factorID": 1,
+      "createdAt": "2025-03-07 14:56:42"
     },
     {
-      "taskID": 22,
-      "factorID": 41
+      "taskID": 1,
+      "factorID": 1,
+      "createdAt": "2025-03-07 14:56:42"
     },
     {
-      "taskID": 21,
-      "factorID": 42
+      "taskID": 1,
+      "factorID": 1,
+      "createdAt": "2025-03-07 14:56:42"
     },
     {
-      "taskID": 22,
-      "factorID": 42
+      "taskID": 1,
+      "factorID": 1,
+      "createdAt": "2025-03-07 14:56:42"
     }
   ],
   "tasks": {
-    "21": {
+    "1": {
       "measurementOptions": [
         "Mouse Movement",
         "Keyboard Inputs",
         "Mouse Scrolls",
         "Mouse Clicks"
       ],
-      "taskDescription": "Task Des",
-      "taskDirections": "Move your mouse foo",
-      "taskDuration": "5.000",
-      "taskName": "Task A"
-    },
-    "22": {
-      "measurementOptions": ["Mouse Movement", "Heat Map", "Screen Recording"],
-      "taskDescription": "Task Des",
-      "taskDirections": "Start spamming keyboard lil bru",
-      "taskDuration": null,
-      "taskName": "Task B"
+      "taskDescription": "A test to assess short-term memory retention",
+      "taskDirections": "Perform the task without visual input. Ensure a safe environment.",
+      "taskDuration": "10.000",
+      "taskName": "Memory Test"
     }
   },
   "factors": {
-    "41": {
-      "factorDescription": "Factor Des",
-      "factorName": "Graph"
-    },
-    "42": {
-      "factorDescription": "Factor Der",
-      "factorName": "Table"
+    "1": {
+      "factorDescription": "Blindfolded",
+      "factorName": "Participants are blindfolded to limit their visual perception."
     }
   }
 }

--- a/server_backend/DEVELOPMENT_running_script/run_sql_refresh_and_flask.sh
+++ b/server_backend/DEVELOPMENT_running_script/run_sql_refresh_and_flask.sh
@@ -187,15 +187,19 @@ csv_counter=1
 trial_counter=1
 study_id=1
 created_at="2025-03-05 00:00:00"
-for participant_id in {1..3}; do
-        path=$(create_data_path_participant "$study_id" "$participant_id")
-        participant_session_id=$(update_database_participant_session "$participant_id")
-    for trial_id in {1..4}; do
-        trial_path=$(create_data_path_trial "$trial_counter" "$participant_id" "$path")
-        csv_counter=$(update_database_trial "$trial_path" "$participant_id" "$study_id" "$csv_counter" "$participant_session_id" "$created_at")
-        trial_counter=$((trial_counter + 1))
-        created_at=$(date -d "$created_at + 2 minute" +"%Y-%m-%d %H:%M:%S")
-    done
+for participant_id in {1..4}; do
+    path=$(create_data_path_participant "$study_id" "$participant_id")
+    participant_session_id=$(update_database_participant_session "$participant_id")
+
+    # Leave 4 blank for testing purposes
+    if [ "$participant_id" -ne 4 ]; then
+        for trial_id in {1..4}; do
+            trial_path=$(create_data_path_trial "$trial_counter" "$participant_id" "$path")
+            csv_counter=$(update_database_trial "$trial_path" "$participant_id" "$study_id" "$csv_counter" "$participant_session_id" "$created_at")
+            trial_counter=$((trial_counter + 1))
+            created_at=$(date -d "$created_at + 2 minute" +"%Y-%m-%d %H:%M:%S")
+        done
+    fi
 done
 
 end_time=$(date +%s)

--- a/server_backend/app/routes/sessions.py
+++ b/server_backend/app/routes/sessions.py
@@ -23,9 +23,10 @@ from app.utility.db_connection import get_db_connection
 bp = Blueprint("sessions", __name__)
 
 
-# Test endpoint for receiving the session zip results from the local script
-@bp.route("/test_local_to_server", methods=["POST"])
-def test_local_to_server():
+# Saving participant session from the local script
+# Excpects a JSON and a zip file with PRECISE naming standards
+@bp.route("/save_participant_session", methods=["POST"])
+def save_participant_session():
     temp_dir = None
     conn = None
 

--- a/server_backend/app/routes/sessions.py
+++ b/server_backend/app/routes/sessions.py
@@ -176,7 +176,7 @@ def test_local_to_server():
                                     session_data_instance_id,
                                 ),
                             )
-
+                            conn.commit()
                             # Print the paths for debugging
                             print(
                                 f"Moving file: {data_instance_path} -> {absolute_data_instance_path}"

--- a/server_backend/app/routes/sessions.py
+++ b/server_backend/app/routes/sessions.py
@@ -107,7 +107,8 @@ def save_participant_session():
                     trial_id = cur.fetchone()[0]
 
                     # Create the path for the trial-specific directory in the participant's results
-                    participant_dir = f"/home/hci/Documents/participants_results/{study_id}_study_id/{participant_session_id}_participant_session_id/{trial_id}_trial_id"
+                    base_dir = current_app.config.get("RESULTS_BASE_DIR_PATH")
+                    participant_dir = f"{base_dir}/{study_id}_study_id/{participant_session_id}_participant_session_id/{trial_id}_trial_id"
                     os.makedirs(participant_dir, exist_ok=True)
 
                     # Find and process the files in the current trial folder

--- a/server_backend/app/utility/sessions.py
+++ b/server_backend/app/utility/sessions.py
@@ -8,63 +8,58 @@ from app.utility.db_connection import get_db_connection
 
 
 def process_trial_file(cur, conn, trial_id, participant_dir, trial_folder, file_name):
-    try:
+    # Full path
+    data_instance_path = os.path.join(trial_folder, file_name)
 
-        data_instance_path = os.path.join(trial_folder, file_name)
-        file_name_without_extension = os.path.splitext(file_name)[0]
-        file_extension = os.path.splitext(file_name)[1]
-        get_measurement_id = """
-        SELECT m.measurement_option_id
-        FROM measurement_option AS m
-        WHERE m.measurement_option_name = %s
-        """
-        cur.execute(get_measurement_id, (file_name_without_extension,))
-        measurement_option_id = cur.fetchone()[0]
+    # Separate name (like Mouse Movement) and extension (like .csv)
+    file_name_without_extension, file_extension = os.path.splitext(file_name)
 
-        insert_session_data_instance = """
-        INSERT INTO session_data_instance (trial_id, measurement_option_id)
-        VALUES(%s, %s)
-        """
-        cur.execute(
-            insert_session_data_instance,
-            (
-                trial_id,
-                measurement_option_id,
-            ),
-        )
-        conn.commit()
-
-        # Get the inserted trial ID
-        cur.execute("SELECT LAST_INSERT_ID()")
-        session_data_instance_id = cur.fetchone()[0]
-
-        # Create the new absolute path for the file in the participant's trial folder
-        absolute_data_instance_path = os.path.join(
-            participant_dir,
-            str(session_data_instance_id) + file_extension,
+    # Fetch measurement option ID
+    get_measurement_id = """
+    SELECT m.measurement_option_id
+    FROM measurement_option AS m
+    WHERE m.measurement_option_name = %s
+    """
+    cur.execute(get_measurement_id, (file_name_without_extension,))
+    result = cur.fetchone()
+    if not result:
+        raise ValueError(
+            f"No measurement option found for '{file_name_without_extension}'"
         )
 
-        update_results_path = """
-        UPDATE session_data_instance
-        SET results_path = %s
-        WHERE session_data_instance_id = %s
-        """
-        cur.execute(
-            update_results_path,
-            (
-                absolute_data_instance_path,
-                session_data_instance_id,
-            ),
-        )
-        conn.commit()
-        # Print the paths for debugging
-        print(f"Moving file: {data_instance_path} -> {absolute_data_instance_path}")
-        # Move (rename) the file to the new location
-        os.rename(data_instance_path, absolute_data_instance_path)
+    measurement_option_id = result[0]
 
-    except Exception as e:
-        raise
-    return
+    # Insert session data instance
+    insert_session_data_instance = """
+    INSERT INTO session_data_instance (trial_id, measurement_option_id)
+    VALUES(%s, %s)
+    """
+    cur.execute(insert_session_data_instance, (trial_id, measurement_option_id))
+    conn.commit()
+
+    # Get the inserted session data instance ID
+    cur.execute("SELECT LAST_INSERT_ID()")
+    session_data_instance_id = cur.fetchone()[0]
+
+    # Create the new absolute path for the file in the participant's trial folder
+    absolute_data_instance_path = os.path.join(
+        participant_dir,
+        f"{session_data_instance_id}{file_extension}",
+    )
+
+    # Update the results path in the database
+    update_results_path = """
+    UPDATE session_data_instance
+    SET results_path = %s
+    WHERE session_data_instance_id = %s
+    """
+    cur.execute(
+        update_results_path, (absolute_data_instance_path, session_data_instance_id)
+    )
+    conn.commit()
+
+    # Save to actual filesystem
+    os.rename(data_instance_path, absolute_data_instance_path)
 
 
 def get_zip(results_with_size, study_id, conn, mode):

--- a/sql_database/sample_data/insert_all.sql
+++ b/sql_database/sample_data/insert_all.sql
@@ -657,11 +657,19 @@ INSERT INTO participant (age, gender_type_id, highest_education_type_id, technol
 VALUES (37, 1, 1, 1);
 INSERT INTO participant (age, gender_type_id, highest_education_type_id, technology_competence)
 VALUES (49, 1, 1, 1);
+
+-- This guy will have no sessions
+INSERT INTO participant (age, gender_type_id, highest_education_type_id, technology_competence)
+VALUES (49, 1, 1, 1);
+
 INSERT INTO participant_ethnicity (participant_id, ethnicity_type_id)
 VALUES 
     (1, 1),
     (1, 2),
-    (1, 3);
+    (1, 3),
+    (4, 3);
+
+
 -- INSERT INTO participant_session (participant_id, study_id, ended_at, comments, is_valid)
 -- VALUES (1, 1, NOW() + INTERVAL 30 MINUTE, "Participant is too smart. Terminate him", 0),
 -- (2, 1, NULL, "They were very nice", 1),


### PR DESCRIPTION
1. Saves inputted ZIP 
2. Does conversions between relative (inputted ZIP) to absolute (ids in filesystem / db) for trial folders and tracked data
3. Database and file system perfectly match up
4. Tons of error checking to know what breaks when
5. Database rollback in case of failure
6. Added blank participant_session during SQL insert table that MATCHES sample_study_json id

NOTES:
1. The endpoint requires an input JSON and input ZIP of EXACT formats. I'll link them to this for reference
[1_participant_session.zip](https://github.com/user-attachments/files/19146519/1_participant_session.zip)
[sample_study.json](https://github.com/user-attachments/files/19146643/sample_study.json)


