### PR TITLE
Auto populate edit study, bug fixes, minor UI improvements 

### DIFF
--- a/frontend/src/components/Task.vue
+++ b/frontend/src/components/Task.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-mutating-props -->
 <template>
   <div>
     <v-text-field
@@ -31,7 +32,7 @@
     <div>
       <v-select
         v-model="task.measurementOptions"
-        :items="updateVisibleMeasurementOptions"
+        :items="updateMeasurementOptions"
         label="Measurement Options"
         chips
         multiple
@@ -58,6 +59,16 @@ export default {
 
   data() {
     return {
+      //Measurement options supported
+      allMeasurementOptions: [
+        'Mouse Movement',
+        'Mouse Scrolls',
+        'Mouse Clicks',
+        'Keyboard Inputs',
+        'Screen Recording',
+        'Heat Map',
+      ],
+
       // validation rules for task-related inputs
       taskNameRules: [
         v => !!v || 'Task name is required.',
@@ -103,40 +114,36 @@ export default {
 
   // Used to remove Heat Map selection if Mouse Movement is deselected since it is dependent on it
   watch: {
-    'task.measurementOptions'(newSelection) {
-      if (!newSelection.includes('Mouse Movement')) {
-        this.$emit('update:task', {
-          ...this.task,
-          measurementOptions: newSelection.filter(
+    'task.measurementOptions': {
+      handler(newSelection) {
+        if (
+          !newSelection.includes('Mouse Movement') &&
+          newSelection.includes('Heat Map')
+        ) {
+          const updatedSelection = newSelection.filter(
             option => option !== 'Heat Map',
-          ),
-        })
-      }
+          )
+          this.$emit('update:task', {
+            ...this.task,
+            measurementOptions: updatedSelection,
+          })
+        }
+      },
+      deep: true,
     },
   },
 
   // Changes selection options to include Heat Map when Mouse Movement is actively selected and vice versa
   computed: {
-    updateVisibleMeasurementOptions() {
-      if (this.task.measurementOptions.includes('Mouse Movement')) {
-        return [
-          // Heat Map should be visible since MM is selected
-          'Mouse Movement',
-          'Mouse Scrolls',
-          'Mouse Clicks',
-          'Keyboard Inputs',
-          'Screen Recording',
-          'Heat Map',
-        ]
+    updateMeasurementOptions() {
+      const mouseMovementSelected =
+        this.task.measurementOptions.includes('Mouse Movement')
+      if (mouseMovementSelected) {
+        return this.allMeasurementOptions
       } else {
-        return [
-          // Heat Map unavailable when Mouse Movement not selected
-          'Mouse Movement',
-          'Mouse Scrolls',
-          'Mouse Clicks',
-          'Keyboard Inputs',
-          'Screen Recording',
-        ]
+        return this.allMeasurementOptions.filter(
+          option => option !== 'Heat Map',
+        )
       }
     },
   },

--- a/frontend/src/views/SessionSetup.vue
+++ b/frontend/src/views/SessionSetup.vue
@@ -25,33 +25,25 @@
               >
               </v-text-field>
               <!-- Randomization btn -->
-              <v-tooltip text="Generate Random Permutation">
-                <template v-slot:activator="{ props }">
-                  <v-btn
-                    v-bind="props"
-                    icon
-                    @click="getPermutation"
-                    color="transparent"
-                    class="ml-2"
-                  >
-                    <v-icon>mdi-dice-6-outline</v-icon>
-                  </v-btn>
-                </template>
-              </v-tooltip>
+              <v-btn
+                v-tooltip="'Generate Random Permutation'"
+                icon
+                @click="getPermutation"
+                color="transparent"
+                class="ml-2"
+              >
+                <v-icon>mdi-dice-6-outline</v-icon>
+              </v-btn>
               <!-- Reset btn -->
-              <v-tooltip text="Reset to Recommended">
-                <template v-slot:activator="{ props }">
-                  <v-btn
-                    v-bind="props"
-                    icon
-                    @click="resetCount"
-                    color="transparent"
-                    class="ml-2"
-                  >
-                    <v-icon>mdi-restart</v-icon>
-                  </v-btn>
-                </template>
-              </v-tooltip>
+              <v-btn
+                v-tooltip="'Reset'"
+                icon
+                @click="resetCount"
+                color="transparent"
+                class="ml-2"
+              >
+                <v-icon>mdi-restart</v-icon>
+              </v-btn>
             </div>
 
             <!-- Warning msg for recommended length -->

--- a/frontend/src/views/StudyPanel.vue
+++ b/frontend/src/views/StudyPanel.vue
@@ -8,10 +8,7 @@
     <v-toolbar flat dense color="white">
       <v-toolbar-title> {{ studyName }}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-btn icon @click="editExistingStudy">
-        <v-icon color="secondary">mdi-pencil</v-icon>
-      </v-btn>
-      <v-btn icon @click="closeDrawer">
+      <v-btn v-tooltip="'Close'" icon @click="closeDrawer">
         <v-icon color="secondary">mdi-close</v-icon>
       </v-btn>
     </v-toolbar>
@@ -71,14 +68,14 @@
               <v-list-item v-for="(task, index) in tasks" :key="index">
                 <v-list-item-title>{{ task.taskName }}</v-list-item-title>
                 <v-list-item-subtitle>{{
-                  task.taskDescription
+                  task.taskDescription || 'No task description provided'
                 }}</v-list-item-subtitle>
                 <p class="task-detail">
                   Duration:
                   {{
-                    task.taskDuration !== 'None'
+                    task.taskDuration && !isNaN(task.taskDuration)
                       ? parseFloat(task.taskDuration).toFixed(2) + ' minutes'
-                      : 'N/A'
+                      : 'No duration set'
                   }}
                 </p>
                 <p class="task-detail">
@@ -108,7 +105,7 @@
               <v-list-item v-for="(factor, index) in factors" :key="index">
                 <v-list-item-title>{{ factor.factorName }}</v-list-item-title>
                 <v-list-item-subtitle>{{
-                  factor.factorDescription
+                  factor.factorDescription || 'No factor description provided'
                 }}</v-list-item-subtitle>
                 <v-divider class="mb-2"></v-divider>
               </v-list-item>
@@ -150,6 +147,7 @@
               </template>
               <template v-slot:item.actions="{ item }">
                 <v-icon
+                  v-tooltip="'Download Results'"
                   class="me-2"
                   size="small"
                   @click.stop="downloadParticipantSessionData(item.sessionID)"
@@ -157,13 +155,14 @@
                   mdi-download
                 </v-icon>
                 <v-icon
+                  v-tooltip="'Open'"
                   class="me-2"
                   size="small"
                   @click.stop="openSession(item)"
                 >
                   mdi-arrow-expand
                 </v-icon>
-                <v-icon size="small"> mdi-delete </v-icon>
+                <v-icon v-tooltip="'Delete'" size="small"> mdi-delete </v-icon>
               </template>
             </v-data-table>
           </v-card>
@@ -290,7 +289,8 @@ export default {
         console.log(this.focus_study)
 
         this.studyName = this.focus_study.studyName
-        this.studyDescription = this.focus_study.studyDescription || 'N/A'
+        this.studyDescription =
+          this.focus_study.studyDescription || 'No study description'
         this.studyDesignType = this.focus_study.studyDesignType
         this.participantCount = this.focus_study.participantCount
         this.tasks = this.focus_study.tasks

--- a/local_backend/driver.py
+++ b/local_backend/driver.py
@@ -426,7 +426,7 @@ class GlobalToolbar(QWidget):
     def display_new_trial_info(self, dur, dir):
         trial_start_msg = QMessageBox()
         trial_start_msg.setWindowTitle(f"Task {self.trial_index + 1}")
-        
+
         contents = ""
         if dir:
             contents += f"Directions: {dir}\n"
@@ -434,7 +434,7 @@ class GlobalToolbar(QWidget):
             contents += f"Duration: {dur} minutes"
         else:
             contents += f"Duration: No time limit"
-        
+
         trial_start_msg.setText(contents)
 
         trial_start_msg.setStandardButtons(QMessageBox.StandardButton.Ok)
@@ -528,7 +528,7 @@ class GlobalToolbar(QWidget):
             task = self.tasks[task_id]
             task_dirs = task["taskDirections"]
             if not task_dirs:
-                task_dirs = 'Ask facilitator for directions if needed'
+                task_dirs = "Ask facilitator for directions if needed"
             help_msg.setText(
                 f"<b>Directions:</b>\n"
                 f"<ul><li>{task_dirs}</li></ul>"
@@ -640,7 +640,7 @@ class GlobalToolbar(QWidget):
         curr_task_id = str(curr_trial["taskID"])
         curr_task = self.tasks[curr_task_id]
         curr_measurements = curr_task["measurementOptions"]
-        
+
         # Accounting for future expansion where the user may bave specified "Other" collection mechanisms which we do not handle tracking for
         supported_measurements = {
             "Mouse Movement",
@@ -650,15 +650,18 @@ class GlobalToolbar(QWidget):
             "Screen Recording",
             "Heat Map",
         }
-        
+
         if set(curr_measurements) & supported_measurements:
             # Have to use while loops here or else while waiting the overlaying pop-up will freeze. Using this we can invoke an update to UI
             if not data_storage_complete_event.is_set():
                 while not data_storage_complete_event.is_set():
                     time.sleep(0.1)
                     QApplication.processEvents()
-                    
-            if "Heat Map" in curr_measurements and not heatmap_generation_complete.is_set():
+
+            if (
+                "Heat Map" in curr_measurements
+                and not heatmap_generation_complete.is_set()
+            ):
                 while not heatmap_generation_complete.is_set():
                     time.sleep(0.1)
                     QApplication.processEvents()

--- a/local_backend/tracking/utility/file_management.py
+++ b/local_backend/tracking/utility/file_management.py
@@ -75,11 +75,17 @@ def package_session_results(session_id, storage_path):
             for trial_folder in os.listdir(dir_session):
                 trial_path = os.path.join(dir_session, trial_folder)
                 if os.path.isdir(trial_path):
-                    for root, _, files in os.walk(trial_path):
-                        for file in files:
-                            file_path = os.path.join(root, file)
-                            arcname = os.path.relpath(file_path, dir_session)
-                            zipf.write(file_path, arcname)
+                    # Empty trial folders (user used alt methods for collecting data) must still be included in zip
+                    if not os.listdir(trial_path):
+                        arcname = os.path.relpath(trial_path, dir_session) + "/"
+                        zip_info = zipfile.ZipInfo(arcname)
+                        zipf.writestr(zip_info, "")
+                    else:
+                        for root, _, files in os.walk(trial_path):
+                            for file in files:
+                                file_path = os.path.join(root, file)
+                                arcname = os.path.relpath(file_path, dir_session)
+                                zipf.write(file_path, arcname)
 
         shutil.rmtree(dir_session)
         print(f"Session {session_id} results saved to {zip_path}!")

--- a/server_backend/app/routes/studies.py
+++ b/server_backend/app/routes/studies.py
@@ -508,16 +508,16 @@ def load_study(study_id):
         # Creating the study obj before adding measurement option info
         study_data = {
             "studyName": study_res[0],
-            "studyDescription": study_res[1] or "No study description provided",
+            "studyDescription": study_res[1],
             "studyDesignType": study_res[4],
             "participantCount": str(study_res[2]),
             "tasks": [
                 {
                     "taskID": task[0],
                     "taskName": task[1],
-                    "taskDescription": task[2] or "No task description provided",
-                    "taskDirections": task[3] or "No task directions provided",
-                    "taskDuration": str(task[4]),
+                    "taskDescription": task[2],
+                    "taskDirections": task[3],
+                    "taskDuration": task[4],
                     "measurementOptions": [],
                 }
                 for task in task_res
@@ -526,7 +526,7 @@ def load_study(study_id):
                 {
                     "factorID": factor[0],
                     "factorName": factor[1],
-                    "factorDescription": factor[2] or "No factor description provided",
+                    "factorDescription": factor[2],
                 }
                 for factor in factor_res
             ],


### PR DESCRIPTION
- After opening an existing study to edit, all fields will be populated with previously entered data
- Fixed recursive issue with the Mouse Movement and Heat Map dependency for the measurement options dropdown in Task.vue
- Added tooltips to various buttons for improved UX 
- Adjusted local scripts to work when a trial has no data collection mechanisms (screen recording, keyboard inputs, etc) selected as previously it would continue waiting for thread signals noting writes were finished that were never active in the first place
- Modified the way zip files get compressed on the local side so empty trial folders are still included that way the filesystem still constructs directories for them which will be useful when users go to upload their external data in later on
- Fixed minor issue with load_study() endpoint as null values were being replaced with string descriptions which was rigid and moved the logic for displaying messages to respective front end locations 