### PR TITLE
Consent Forms and Session Workflow Updates

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,8 +18,9 @@
         "vue": "^3.5.11",
         "vue-router": "^4.4.5",
         "vue3-apexcharts": "^1.8.0",
+        "vue3-pdf-app": "^1.0.3",
         "vuedraggable": "^4.1.0",
-        "vuetify": "^3.7.2"
+        "vuetify": "^3.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
@@ -8953,6 +8954,15 @@
         "vue": ">=3.0.0"
       }
     },
+    "node_modules/vue3-pdf-app": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vue3-pdf-app/-/vue3-pdf-app-1.0.3.tgz",
+      "integrity": "sha512-qegWTIF4wYKiocZ3KreB70wRXhqSdXWbdERDyyKzT7d5PbjKbS9tD6vaKkCqh3PzTM84NyKPYrQ3iuwJb60YPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vuedraggable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
@@ -8966,9 +8976,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.2.tgz",
-      "integrity": "sha512-q0WTcRG977+a9Dqhb8TOaPm+Xmvj0oVhnBJhAdHWFSov3HhHTTxlH2nXP/GBTXZuuMHDbBeIWFuUR2/1Fx0PPw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.0.tgz",
+      "integrity": "sha512-ROC0Xq2G/25ZyUpQMhaynMyXZBJY1WbOGlqOB810yubp8hfY8RlrOw+mzXJonOq6jylCY32muQ9xiJF1JPTLVA==",
       "license": "MIT",
       "engines": {
         "node": "^12.20 || >=14.13"
@@ -8979,9 +8989,9 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=1.0.0",
-        "vue": "^3.3.0",
-        "webpack-plugin-vuetify": ">=2.0.0"
+        "vite-plugin-vuetify": ">=2.1.0",
+        "vue": "^3.5.0",
+        "webpack-plugin-vuetify": ">=3.1.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,8 +24,9 @@
     "vue": "^3.5.11",
     "vue-router": "^4.4.5",
     "vue3-apexcharts": "^1.8.0",
+    "vue3-pdf-app": "^1.0.3",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^3.7.2"
+    "vuetify": "^3.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.12.0",

--- a/frontend/src/components/ConsentAckScreen.vue
+++ b/frontend/src/components/ConsentAckScreen.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-dialog v-model="visible" persistent class="consent-dialog">
+    <template v-slot:default="{ isActive }">
+      <v-card title="Participant Consent Agreement">
+        <v-card-text>
+          <pdf-app
+            v-if="fileURL"
+            :pdf="fileURL"
+            style="height: 500px"
+            :show-toolbar="true"
+            :toolbar-options="{
+              zoom: true,
+              download: false,
+              print: false,
+              pager: true,
+            }"
+          >
+          </pdf-app>
+          <v-alert v-else type="error" variant="tonal"
+            >Error loading consent form</v-alert
+          >
+        </v-card-text>
+        <v-card-actions class="d-flex justify-space-between">
+          <v-checkbox
+            v-model="acknowledgeVal"
+            label="I acknowledge"
+          ></v-checkbox>
+          <v-btn
+            text="Continue"
+            :disabled="!acknowledgeVal"
+            @click="saveConsent"
+          ></v-btn>
+        </v-card-actions>
+      </v-card>
+    </template>
+  </v-dialog>
+</template>
+<script>
+import PdfApp from 'vue3-pdf-app'
+export default {
+  components: {
+    PdfApp,
+  },
+  props: {
+    display: Boolean,
+    form: {
+      type: [File, null],
+      required: true,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      acknowledgeVal: false,
+      fileURL: null,
+    }
+  },
+  computed: {
+    // Needed to avoid prop mutation
+    visible: {
+      get() {
+        return this.display
+      },
+      set(newVal) {
+        this.$emit('update:display', newVal)
+      },
+    },
+  },
+  watch: {
+    display(newVal) {
+      // Have to create temp URL for local File obj
+      if (newVal && this.form instanceof File) {
+        this.fileURL = URL.createObjectURL(this.form)
+      }
+      // Cleanup blob if needed
+      else if (!newVal && this.fileURL) {
+        URL.revokeObjectURL(this.fileURL)
+      }
+    },
+  },
+  methods: {
+    saveConsent() {
+      this.acknowledgeVal = false
+      this.$emit('acknowledged')
+      this.$emit('update:display', false) // Close dialog
+    },
+  },
+}
+</script>
+<style scoped>
+.consent-dialog {
+  width: 60vw;
+  max-width: 1500px;
+  max-height: none;
+}
+</style>

--- a/frontend/src/components/CountdownTimer.vue
+++ b/frontend/src/components/CountdownTimer.vue
@@ -1,0 +1,99 @@
+<template>
+  <div v-if="start" class="timer-counter">
+    <v-progress-circular
+      :model-value="progressTimer"
+      :size="150"
+      :width="15"
+      color="primary"
+    >
+    </v-progress-circular>
+    <div class="timer-msgs">
+      <p class="timer-msg">Starting in {{ timer }} seconds...</p>
+      <p class="timer-mini-msg">
+        {{ description }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    duration: {
+      type: Number,
+      default: 20,
+    },
+    start: {
+      type: Boolean,
+      default: false,
+    },
+    description: {
+      type: String,
+      default: 'About to begin',
+    },
+  },
+  data() {
+    return {
+      timer: 0,
+      timerInterval: null,
+    }
+  },
+  computed: {
+    // Updates UI of circular progress
+    progressTimer() {
+      return (this.timer / this.duration) * 100
+    },
+  },
+
+  watch: {
+    // Trigger the countdown start
+    start(newVal) {
+      if (newVal) {
+        this.startCountdown()
+      }
+    },
+  },
+
+  methods: {
+    // Logic for the countdown itself, including emitting signal upon completion
+    startCountdown() {
+      this.timer = this.duration
+      this.timerInterval = setInterval(() => {
+        if (this.timer > 0) {
+          this.timer -= 1
+        } else {
+          clearInterval(this.timerInterval)
+          this.$emit('countdown-complete')
+        }
+      }, 1000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.v-progress-circular {
+  margin: 1rem;
+}
+.timer-counter {
+  width: 100%;
+  height: 100vh;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.timer-msgs {
+  text-align: center;
+  margin-top: 1rem;
+}
+.timer-msg {
+  font-size: 1.5rem;
+  color: #555;
+}
+.timer-mini-msg {
+  font-size: 1rem;
+  color: #777;
+  margin-top: 0.5rem;
+}
+</style>

--- a/frontend/src/components/FileUploadAndPreview.vue
+++ b/frontend/src/components/FileUploadAndPreview.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-row class="mt-4">
+    <!-- File upload field -->
+    <v-col cols="6">
+      <v-file-input
+        :model-value="modelValue"
+        :label="label"
+        :accept="accept"
+        variant="outlined"
+        show-size
+        hide-details
+        clearable
+        @update:modelValue="$emit('update:modelValue', $event)"
+      ></v-file-input>
+    </v-col>
+
+    <!-- Preview button -->
+    <v-col cols="2" class="d-flex align-center">
+      <v-btn
+        variant="text"
+        color="primary"
+        prepend-icon="mdi-eye-outline"
+        @click="$emit('preview')"
+        :disabled="!modelValue"
+      >
+        Preview
+      </v-btn>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  props: {
+    modelValue: {
+      type: [File, Object, null],
+      required: false,
+      default: null,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    accept: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue', 'preview'],
+  watch: {
+    modelValue(newVal) {
+      if (newVal == undefined || newVal == null) {
+        this.$emit('update:modelValue', null)
+      }
+    },
+  },
+}
+</script>

--- a/frontend/src/components/StudyPanel.vue
+++ b/frontend/src/components/StudyPanel.vue
@@ -385,17 +385,9 @@ export default {
       }
     },
 
-    // Route to an empty study form page
+    // Route to view for session setup
     startNewSession() {
       this.$router.push({ name: 'SessionSetup', params: { id: this.studyID } })
-    },
-
-    // Route to a pre-populated study form pg
-    editExistingStudy() {
-      this.$router.push({
-        name: 'StudyForm',
-        params: { studyID: this.studyID, userID: 1 }, // 1 is hardcoded for now until we have users
-      })
     },
   },
 }

--- a/frontend/src/components/Task.vue
+++ b/frontend/src/components/Task.vue
@@ -86,10 +86,16 @@ export default {
           'Task directions must be less than 250 characters.',
       ],
       taskDurationRules: [
-        v =>
-          v === '' ||
-          Number(v) > 0 ||
-          'A set duration must be greater than 0 min.',
+        v => {
+          if (v == '') {
+            return true
+          }
+          const num = Number(v)
+          return (
+            (Number.isFinite(num) && num > 0) ||
+            'A set duration must be greater than 0 min.'
+          )
+        },
       ],
     }
   },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,7 +11,6 @@ import SessionForm from '../views/SessionForm.vue'
 import TestSendCSV from '../views/TestCSVToServer.vue'
 import TestGetCSVInfo from '../views/TestGetCSVInfo.vue'
 import TestGetParticipantSessionCSVInfo from '../views/TestGetParticipantSessionCSVInfo.vue'
-import axios from 'axios'
 import SessionSetup from '@/views/SessionSetup.vue'
 
 const router = createRouter({

--- a/frontend/src/views/SessionSetup.vue
+++ b/frontend/src/views/SessionSetup.vue
@@ -156,10 +156,10 @@
         ><strong>+ Add Another Trial</strong></v-btn
       >
 
-      <!-- Next and Cancel btns-->
+      <!-- Begin and Cancel btns-->
       <v-row justify="center" class="btn-row">
         <v-btn
-          class="me-4 cancel-next-btn"
+          class="me-4 cancel-begin-btn"
           color="error"
           @click="
             displayDialog({
@@ -171,10 +171,10 @@
           >Cancel</v-btn
         >
         <v-btn
-          class="me-4 cancel-next-btn"
+          class="me-4 cancel-begin-btn"
           @click="attemptToAdvance"
           :color="isFormIncomplete ? '#b7ccb2' : 'success'"
-          >Next</v-btn
+          >Begin</v-btn
         >
       </v-row>
 
@@ -202,20 +202,10 @@
 
 <script>
 import axios from 'axios'
-import { useRouter } from 'vue-router'
 import draggable from 'vuedraggable'
 import CoverageHeatmap from '@/components/CoverageHeatmap.vue'
 
 export default {
-  setup() {
-    const router = useRouter()
-    const exit = () => {
-      router.go(-1)
-    }
-
-    return { exit }
-  },
-
   components: {
     draggable,
     CoverageHeatmap,
@@ -231,7 +221,7 @@ export default {
       factorOptions: [],
       // Stores the currently defined trials
       trials: [],
-      // Used for populating dialog pop-ups under diff conditions (ex. cancel vs next)
+      // Used for populating dialog pop-ups under diff conditions (ex. cancel vs begin)
       dialog: false,
       dialogDetails: {
         title: '',
@@ -296,19 +286,22 @@ export default {
   },
 
   methods: {
-    // Dynamic confirmation for canceling or moving to next part of session setup
+    // Dynamic confirmation for canceling or beginning session
     displayDialog(details) {
       this.dialogDetails = details
       this.dialog = true
     },
 
-    // If they agree to canceling we route elsewhere & if they click continue we route to next part
+    // If they agree to canceling we route elsewhere & if they click continue we route to demographics form
     closeDialog(source) {
-      if (source == 'next') {
+      if (source == 'begin') {
         this.formatStudy()
         this.goToParticipantForm()
       } else if (source == 'cancel') {
-        this.exit()
+        this.$router.push({
+          name: 'UserStudies',
+          query: { studyID: this.studyId },
+        })
       }
       this.dialog = false
     },
@@ -505,7 +498,7 @@ export default {
       }
     },
 
-    // Logic for whether the user clicking "Next" should work or not
+    // Logic for whether the user clicking "Begin" should work or not
     attemptToAdvance() {
       this.formValidated = true
 
@@ -513,9 +506,9 @@ export default {
         return
       } else {
         this.displayDialog({
-          title: 'Continue',
-          text: 'Are you sure you want to move on to the Participant Demographics Form?',
-          source: 'next',
+          title: 'Begin Session',
+          text: 'Are you sure you want to start the session?',
+          source: 'begin',
         })
       }
     },
@@ -555,7 +548,7 @@ export default {
   display: flex;
   margin-top: 50px;
 }
-.cancel-next-btn {
+.cancel-begin-btn {
   min-height: 40px;
   min-width: 200px;
 }

--- a/frontend/src/views/StudyForm.vue
+++ b/frontend/src/views/StudyForm.vue
@@ -141,7 +141,44 @@
               </v-btn>
             </div>
 
-            <v-row class="btn-row" justify="center">
+            <h3>Forms/Uploads</h3>
+            <div class="text-medium-emphasis">
+              (All file uploads below are optional)
+            </div>
+            <!-- Consent Form Upload -->
+            <FileUploadAndPreview
+              v-model="consentForm"
+              label="Consent Form (PDF)"
+              accept=".pdf,.txt,.md"
+              @preview="previewConsentForm"
+            ></FileUploadAndPreview>
+
+            <!-- May remove these if I decide to not use yaml files but a form API instead -->
+
+            <!-- Pre-survey Questions Upload (Optional)-->
+            <FileUploadAndPreview
+              v-model="preSurveyFile"
+              label="Pre-survey Questionnaire (YAML)"
+              accept=".yaml,.yml"
+              @preview="previewConsentForm"
+            ></FileUploadAndPreview>
+
+            <!-- Post-survey Questions Upload (Optional)-->
+            <FileUploadAndPreview
+              v-model="postSurveyFile"
+              label="Post-survey Questionnaire (YAML)"
+              accept=".yaml,.yml"
+              @preview="previewConsentForm"
+            ></FileUploadAndPreview>
+
+            <!-- -->
+
+            <ConsentAckScreen
+              v-model:display="showConsentPreview"
+              :form="consentForm"
+            />
+
+            <v-row class="btn-row mt-8" justify="center">
               <v-btn
                 class="me-4 save-exit-btn"
                 @click="
@@ -206,14 +243,21 @@ import Factor from '../components/Factor.vue'
 import axios from 'axios'
 import { useRouter } from 'vue-router'
 import { ref } from 'vue'
+import FileUploadAndPreview from '@/components/FileUploadAndPreview.vue'
+import ConsentAckScreen from '@/components/ConsentAckScreen.vue'
 
 export default {
-  components: { Task, Factor },
+  components: {
+    Task,
+    Factor,
+    FileUploadAndPreview,
+    ConsentAckScreen,
+  },
 
   setup() {
     const router = useRouter()
     const exit = () => {
-      router.go(-1)
+      router.push({ name: 'UserStudies' })
     }
     const factorRefs = ref([])
     const taskRefs = ref([])
@@ -233,6 +277,11 @@ export default {
       // used to track the state of task & factor expansion panels
       expandedTPanels: [0],
       expandedFPanels: [0],
+      // Forms
+      consentForm: null,
+      showConsentPreview: false,
+      preSurveyFile: null,
+      postSurveyFile: null,
       // input validation for form fields (not tasks or factors)
       studyNameRules: [
         v => !!v || 'Study name is required.',
@@ -408,6 +457,12 @@ export default {
       this.dialog = false
     },
 
+    previewConsentForm() {
+      if (this.consentForm) {
+        this.showConsentPreview = true
+      }
+    },
+
     studySaveStatus(type, msg) {
       this.alertType = type
       this.alertMessage = msg
@@ -421,7 +476,7 @@ export default {
     async fetchStudyDetails(studyID) {
       try {
         const backendUrl = this.$backendUrl
-        const path = `${backendUrl}/load_study/${studyID}`
+        let path = `${backendUrl}/load_study/${studyID}`
         const response = await axios.get(path)
 
         const study_edit = response.data
@@ -430,8 +485,32 @@ export default {
         this.studyDescription = study_edit.studyDescription
         this.studyDesignType = study_edit.studyDesignType
         this.participantCount = study_edit.participantCount
-        this.tasks = study_edit.tasks
+        this.tasks = study_edit.tasks.map(task => ({
+          ...task,
+          taskDuration: task.taskDuration !== null ? task.taskDuration : '',
+        }))
         this.factors = study_edit.factors
+
+        // Consent form
+        try {
+          path = `${backendUrl}/get_study_consent_form/${studyID}`
+          const consentResponse = await axios.get(path, {
+            responseType: 'blob',
+          })
+          if (consentResponse.status == 200) {
+            const fName =
+              consentResponse.headers['x-original-filename'] ||
+              'consent_form.pdf'
+            const blob = new File([consentResponse.data], fName, {
+              type: 'application/pdf',
+            })
+            this.consentForm = blob
+          }
+        } catch (err) {
+          if (err.response.status !== 204) {
+            console.warn('Consent form retrieval failed:', err)
+          }
+        }
       } catch (error) {
         console.error('Error fetching details of existing study:', error)
       }
@@ -456,19 +535,28 @@ export default {
         })),
       }
 
-      console.log(JSON.stringify(submissionData, null, 2))
       try {
         const backendUrl = this.$backendUrl
         let path
+        const formData = new FormData()
+
+        formData.append('data', JSON.stringify(submissionData))
+        if (this.consentForm) {
+          formData.append('consent_file', this.consentForm)
+        }
+
         let response
-        // Making new study vs editing
+        // Editing existing study > overwrite
         if (this.studyID && this.userID) {
           path = `${backendUrl}/overwrite_study/${this.userID}/${this.studyID}`
-          response = await axios.put(path, submissionData)
+          response = await axios.post(path, formData)
         } else {
+          // Creating a new study
           path = `${backendUrl}/create_study/1`
-          response = await axios.post(path, submissionData)
+          response = await axios.post(path, formData)
         }
+
+        // Everything successfully saved
         this.studySaveStatus('success', 'Study saved successfully!')
         setTimeout(() => {
           this.exit()

--- a/server_backend/app/routes/sessions.py
+++ b/server_backend/app/routes/sessions.py
@@ -723,8 +723,12 @@ def get_participant_session_data(study_id, participant_session_id):
 
         return jsonify({"error_type": error_type, "error_message": error_message}), 500
 
+
 # Stores the participant's consent agreement for individual sessions
-@bp.route("/save_participant_consent/<int:study_id>/<int:participant_session_id>", methods=["POST"])
+@bp.route(
+    "/save_participant_consent/<int:study_id>/<int:participant_session_id>",
+    methods=["POST"],
+)
 def save_participant_consent(study_id, participant_session_id):
     try:
         # Establish DB connection
@@ -739,13 +743,13 @@ def save_participant_consent(study_id, participant_session_id):
         """
         cur.execute(consent_form_id_query, (study_id,))
         result = cur.fetchone()
-        
+
         if result is None:
             return jsonify({"error": "Failed to find consent form id"}), 400
-        
+
         consent_form_id = result[0]
 
-        # Update consent ack tbl & prevent duplicates 
+        # Update consent ack tbl & prevent duplicates
         insert_consent_agreement_query = """
         INSERT IGNORE INTO consent_ack (consent_form_id, participant_session_id)
         VALUES (%s, %s)

--- a/server_backend/app/routes/sessions.py
+++ b/server_backend/app/routes/sessions.py
@@ -722,3 +722,49 @@ def get_participant_session_data(study_id, participant_session_id):
         error_message = str(e)
 
         return jsonify({"error_type": error_type, "error_message": error_message}), 500
+
+# Stores the participant's consent agreement for individual sessions
+@bp.route("/save_participant_consent/<int:study_id>/<int:participant_session_id>", methods=["POST"])
+def save_participant_consent(study_id, participant_session_id):
+    try:
+        # Establish DB connection
+        conn = get_db_connection()
+        cur = conn.cursor()
+
+        # Get consent form id
+        consent_form_id_query = """
+        SELECT consent_form_id
+        FROM consent_form
+        WHERE study_id = %s
+        """
+        cur.execute(consent_form_id_query, (study_id,))
+        result = cur.fetchone()
+        
+        if result is None:
+            return jsonify({"error": "Failed to find consent form id"}), 400
+        
+        consent_form_id = result[0]
+
+        # Update consent ack tbl & prevent duplicates 
+        insert_consent_agreement_query = """
+        INSERT IGNORE INTO consent_ack (consent_form_id, participant_session_id)
+        VALUES (%s, %s)
+        """
+        cur.execute(
+            insert_consent_agreement_query, (consent_form_id, participant_session_id)
+        )
+
+        # Commit changes to the database
+        conn.commit()
+
+        # Close cursor
+        cur.close()
+        return jsonify({"message": "Participant consent saved successfully"}), 200
+
+    except Exception as e:
+        # Error message
+        error_type = type(e).__name__
+        error_message = str(e)
+
+        # 500 means internal error, AKA the database probably broke
+        return jsonify({"error_type": error_type, "error_message": error_message}), 500

--- a/server_backend/app/utility/studies.py
+++ b/server_backend/app/utility/studies.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import os
 
+
 def set_available_features(task_measurments):
     # makes sures the default taks are false
     default_tasks = {
@@ -122,16 +123,17 @@ def create_study_task_factor_details(study_id, submissionData, cur):
                 factor_description,
             ),
         )
-        
+
+
 # Stores consent form in the study-level dir in the filesystem
 def save_study_consent_form(study_id, file, cur, base_dir):
     # Check if the file is a PDF
-    if not file.filename.lower().endswith('.pdf'):
+    if not file.filename.lower().endswith(".pdf"):
         raise ValueError("Invalid file type. Only PDF files are allowed.")
 
     # User passed filename
     original_filename = file.filename
-    
+
     # Constructing path
     full_path = os.path.join(base_dir, f"{study_id}_study_id")
     os.makedirs(full_path, exist_ok=True)
@@ -152,6 +154,7 @@ def save_study_consent_form(study_id, file, cur, base_dir):
     """
     cur.execute(insert_consent_form, (study_id, file_path, original_filename))
 
+
 # Removing consent form
 def remove_study_consent_form(study_id, cur):
     # Get file path if one exists
@@ -162,18 +165,18 @@ def remove_study_consent_form(study_id, cur):
     """
     cur.execute(look_path, (study_id,))
     result = cur.fetchone()
-    
+
     if not result:
         return
-    
+
     file_path = result[0]
-        
+
     if file_path and os.path.isfile(file_path):
         try:
             os.remove(file_path)
         except Exception as err:
             print(f"Failed removing file at {file_path}: {err}")
-    
+
     # Updating consent form tbl to reflect deletion
     delete_consent_tbl_entry = """
     DELETE

--- a/sql_database/create_tables.sql
+++ b/sql_database/create_tables.sql
@@ -191,3 +191,22 @@ CREATE TABLE deleted_study_role (
     FOREIGN KEY (user_id) REFERENCES user(user_id),
     FOREIGN KEY (study_user_role_type_id) REFERENCES study_user_role_type(study_user_role_type_id)
 );
+-- Template consent form saved at the study level
+CREATE TABLE consent_form (
+    consent_form_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    study_id INT NOT NULL UNIQUE,
+    file_path VARCHAR(255) NOT NULL,
+    original_filename VARCHAR(255),
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    FOREIGN KEY (study_id) REFERENCES study(study_id)
+);
+-- Acknowledge stored for each session 
+CREATE TABLE consent_ack (
+    consent_ack_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    consent_form_id INT NOT NULL,
+    participant_session_id INT NOT NULL,
+    ack_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE (consent_form_id, participant_session_id),
+    FOREIGN KEY (consent_form_id) REFERENCES consent_form(consent_form_id),
+    FOREIGN KEY (participant_session_id) REFERENCES participant_session(participant_session_id)
+);


### PR DESCRIPTION
**Dependencies**
- Installed a PDF viewer for consent forms with "npm install vue3-pdf-app"
- Updated to the newest Vuetify version with "npm install vuetify@latest"

**Consent Forms**
- User can now upload pdf consent forms during study creation
- User can preview their upload, which shows them what the consent dialog screen will look like during sessions
- Created endpoints for saving and retrieving consent forms, which are stored at the study level in the filesystem
- Created an endpoint for saving consent acknowledgements, which are the proof that a participant agreed to participate
- Integrated consent form into the session flow (SessionForm.vue)
- Editing an existing study, the consent form is retrieved (if there was one in the first place) and users can upload new consent forms, which will replace the existing one in the filesystem
- Endpoints for create study and overwrite study are updated to include consent form saving if provided, and ensure that saves are atomic so that if saving the study details or the consent form fails individually, we rollback to avoid dangling references 

**Other Additions**
- Removed the countdown timer that would appear as a session was about to start and put it in its own component for later use, as with pre-questionnaires coming soon this should not be used on the SessionForm.vue 
- QOL improvement, so if a user exits the session setup (SessionSetup.vue) it navigates back to the UserStudies.vue but immediately opens the study panel that was previously open (seeding the view)
- Fixed issue where if editing a study that had tasks set with no durations, it would consider it invalid even though no duration should be accepted
- Moved the StudyPanel.vue into the components folder instead of view because it is not its own view and uses props to update when opening individual studies on UserStudies.vue 